### PR TITLE
Path names were invalid for RemoteComponent

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -27,7 +27,7 @@
         "Modules": {
           "$className": "Folder",
           "RemoteComponent": {
-            "$path": "lib/RemoteComponent/src/RemoteComponent.lua"
+            "$path": "lib/RemoteComponent/src/RemoteComponent"
           }
         }
       }
@@ -42,7 +42,7 @@
           "Modules": {
             "$className": "Folder",
             "RemoteComponent": {
-              "$path": "lib/RemoteComponent/src/RemoteComponent.lua"
+              "$path": "lib/RemoteComponent/src/RemoteComponent"
             }
           }
         }


### PR DESCRIPTION
Rojo crashes otherwise. This fixes it.